### PR TITLE
Declare Lumo as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ and post it to Mastodon
 ### installation
 
 1. install [Node.js](https://nodejs.org/en/)
-2. install [Lumo](https://github.com/anmonteiro/lumo): `npm install -g lumo-cljs`
-3. run `npm install` to install Node modules
+2. run `npm install` to install Node modules
+3. run `npm start` to, well, start
 
 ### usage
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "repository": "https://github.com/yogthos/mastodon-bot",
   "license": "MIT",
   "dependencies": {
+    "lumo-cljs": "^1.8.0",
     "mastodon-api": "1.3.0",
     "twitter": "1.7.1"
+  },
+  "scripts": {
+    "start": "./mastodon-bot.cljs"
   }
 }


### PR DESCRIPTION
This means that we always have the right version, regardless of what's in the global environment. Note that npm scripts (including `npm start`) automatically prepend `./node_modules/.bin` to $PATH, which is how this works.

See also http://module.party