### PR TITLE
Exclude replies

### DIFF
--- a/mastodon-bot.cljs
+++ b/mastodon-bot.cljs
@@ -146,7 +146,7 @@
          (doseq [account (-> config :twitter :accounts)]
            (.get twitter-client
                  "statuses/user_timeline"
-                 #js {:screen_name account :include_rts false}
+                 #js {:screen_name account :include_rts false :exclude_replies true}
                  (post-tweets last-post-time))))
      ;;post from Tumblr
      (when-let [tumblr-oauth (some-> config :tumblr :access-keys clj->js)]


### PR DESCRIPTION
Added the available parameter in the Twitter client to remove replies from the retrieved tweets https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline.html

This solves #8 in essence without any regex. Anyway, as I explain in the comment of that issue, there is a problem with regex that should be fixed in another pull request.