### PR TITLE
twitter: (partly) fix include-rts/include-replies logic

### DIFF
--- a/mastodon-bot.cljs
+++ b/mastodon-bot.cljs
@@ -192,8 +192,8 @@
                  "statuses/user_timeline"
                  #js {:screen_name account
                       :tweet_mode "extended"
-                      :include_rts (boolean include-replies?)
-                      :exclude_replies (boolean include-rts?)}
+                      :include_rts (boolean include-rts?)
+                      :exclude_replies (not (boolean include-replies?))}
                  (post-tweets last-post-time)))))
      ;;post from Tumblr
      (when-let [{:keys [access-keys accounts limit tumblr-oauth]} (:tumblr config)]


### PR DESCRIPTION
The first problem was that the variable names were switched, the second was that the API variable is named "exclude_replies" while the config option is named "include_replies?", so a negation is needed.  

Even after this fix, I was wondering why some posts from Twitter were not posted to Mastodon when I had configured `:include_replies? false`. It turns out that the option `exclude_replies` to the [GET statuses/user_timeline](https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline.html) method is very inflexible and filters out both replies to own tweets, which Twitter shows publicly by default, as well as replies to other accounts, which Twitter doesn't show publicly by default. So I guess there is some work needed to check if the replied-to account is the own account to emulate Twitter's behaviour.