### PR TITLE
Add npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}
         draft: false
-        prerelease: true
+        prerelease: false
 
     - name: Upload Release Asset
       id: upload-release-asset 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,6 @@ jobs:
         sha256sum mastodon-bot.js > target/mastodon-bot.js.sha256
         sha512sum mastodon-bot.js > target/mastodon-bot.js.sha512
 
-    - name: package release
-      run: |
-        mkdir -p target/npm-build        
-        cp mastodon-bot.js target/npm-build/
-        cp target/mastodon-bot.js.sha256 target/npm-build/
-        cp target/mastodon-bot.js.sha512 target/npm-build/
-        cp package.json target/npm-build/
-        cp README.md target/npm-build/
-        tar -cz -C target/npm-build -f target/npm-build.tgz .
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -98,3 +88,16 @@ jobs:
         asset_path: ./target/mastodon-bot.js.sha512
         asset_name: mastodon-bot.js.sha512
         asset_content_type: application/json
+
+    - name: upload to npm
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        mkdir -p target/npm-build        
+        cp mastodon-bot.js target/npm-build/
+        cp target/mastodon-bot.js.sha256 target/npm-build/
+        cp target/mastodon-bot.js.sha512 target/npm-build/
+        cp package.json target/npm-build/
+        cp README.md target/npm-build/
+        tar -cz -C target/npm-build -f target/npm-build.tgz .
+        npm publish ./target/npm-build.tgz --access public --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release prod
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9]+'
+    tags: '[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   test-matrix:
@@ -42,11 +42,15 @@ jobs:
       run: |
         shadow-cljs release app
         chmod a+x mastodon-bot.js
+        sha256sum mastodon-bot.js > target/mastodon-bot.js.sha256
+        sha512sum mastodon-bot.js > target/mastodon-bot.js.sha512
 
     - name: package release
       run: |
         mkdir -p target/npm-build        
         cp mastodon-bot.js target/npm-build/
+        cp target/mastodon-bot.js.sha256 target/npm-build/
+        cp target/mastodon-bot.js.sha512 target/npm-build/
         cp package.json target/npm-build/
         cp README.md target/npm-build/
         tar -cz -C target/npm-build -f target/npm-build.tgz .
@@ -62,8 +66,8 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Upload Release Asset
-      id: upload-release-asset 
+    - name: Upload mastodon-bot.js
+      id: upload-mastodon-bot-js
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,4 +75,26 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./mastodon-bot.js
         asset_name: mastodon-bot.js
+        asset_content_type: application/json
+
+    - name: Upload mastodon-bot.js.sha256
+      id: upload-mastodon-bot-js-sha256
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./target/mastodon-bot.js.sha256
+        asset_name: mastodon-bot.js.sha256
+        asset_content_type: application/json
+
+    - name: Upload mastodon-bot.js.sha512
+      id: upload-mastodon-bot-js-sha512
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./target/mastodon-bot.js.sha512
+        asset_name: mastodon-bot.js.sha512
         asset_content_type: application/json

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ master ]
   push: 
-    branches: [ '!master' ]
+    ingnored-branches: [ 'master' ]
 
 jobs:
   test-matrix:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,6 +3,7 @@ name: test PR
 on:
   pull_request:
     branches: [ master ]
+  push: [ '!master' ]
 
 jobs:
   test-matrix:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,7 +3,8 @@ name: test PR
 on:
   pull_request:
     branches: [ master ]
-  push: [ '!master' ]
+  push: 
+    branches: [ '!master' ]
 
 jobs:
   test-matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM node:10-slim
 RUN apt-get update && apt-get install --assume-yes software-properties-common && \
   apt-get install --assume-yes git cron
 
-RUN git clone https://github.com/yogthos/mastodon-bot /mastodon-bot && \
-  cd /mastodon-bot && npm install && \
-  npm install -g lumo-cljs
+RUN npm install -g mastodon-bot
 
 RUN mkdir /config && touch /config/config.edn && touch /var/log/cron.log
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ the bot will post the timeline from the specified Twitter/Tumblr accounts and RS
 
 ### installation
 
-1. prerequisits
-1.1 [Node.js](https://nodejs.org/en/)
-1.2 npm
-2. install with `sudo npm install mastodon-bot -g`
-3. run with `mastodon-bot -h`
+1. prerequisits: should be installed: [Node.js](https://nodejs.org/en/), npm
+2. install mastodon-bot with: `sudo npm install mastodon-bot -g`
+3. run with: `mastodon-bot -h`
 
 
 ### usage

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mastodon-bot",
   "description": "Bot to publish twitter, tumblr or rss posts to an mastodon account.",
   "author": "Dmitri Sotnikov",
-  "version": "1.0.0",
+  "version": "1.0.1-dev-0",
   "homepage": "https://github.com/yogthos/mastodon-bot",
   "repository": "https://github.com/yogthos/mastodon-bot",
   "license": "MIT",

--- a/poll.sh
+++ b/poll.sh
@@ -3,7 +3,7 @@
 while true; do
   echo "Polling Bot"
   cd /mastodon-bot
-  npm start
+  mastodon-bot
   echo "Poll done, waiting 600 seconds"
   sleep 600
 done


### PR DESCRIPTION
Sorry for not being careful for the 1.0.0 releasing process. But I think we should not go back in version no just to get a clean 1.0.0 ... :-(

What I've improved:
* Fixed the CI for PR-Requests
* enhanced release tags regex for being able to release also 0.0.0-dev-x tags
* added sha checksums (beeing uploaded in GH-releases section & packaged in npms tgz)
* added a first try for npm publish (dry-run at the moment)
* also fixed the dockerfile & README for using the new npm based installation.

The npm publish step requires a github-secret `NPM_TOKEN`.
You can create this on npm in the Auth-Token section & you can store this on Github in project-settings / secrets.

You can test the process if you push a tag like '1.0.1-dev-0'.
It should look somehow like https://github.com/DomainDrivenArchitecture/mastodon-bot/runs/819574051?check_suite_focus=true#step:11:1

If everything is fine, we can remove the dry-run, tag again and enjoy our first ci-driven version in GH releases and on npm.