### PR TITLE
npm package tgz should contain a single folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,11 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
-        mkdir -p target/npm-build        
-        cp mastodon-bot.js target/npm-build/
-        cp target/mastodon-bot.js.sha256 target/npm-build/
-        cp target/mastodon-bot.js.sha512 target/npm-build/
-        cp package.json target/npm-build/
-        cp README.md target/npm-build/
+        mkdir -p target/npm-build/mastodon_bot
+        cp mastodon-bot.js target/npm-build/mastodon_bot/
+        cp target/mastodon-bot.js.sha256 target/npm-build/mastodon_bot/
+        cp target/mastodon-bot.js.sha512 target/npm-build/mastodon_bot/
+        cp package.json target/npm-build/mastodon_bot/
+        cp README.md target/npm-build/mastodon_bot/
         tar -cz -C target/npm-build -f target/npm-build.tgz .
         npm publish ./target/npm-build.tgz --access public --dry-run

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,10 +7,10 @@ shadow-cljs compile test
 shadow-cljs release app
 chmod a+x mastodon-bot.js
 rm -rf target/npm-build 
-mkdir target/npm-build
-cp mastodon-bot.js target/npm-build/
-cp package.json target/npm-build/
-cp README.md target/npm-build/
+mkdir -p target/npm-build/mastodon_bot
+cp mastodon-bot.js target/npm-build/mastodon_bot/
+cp package.json target/npm-build/mastodon_bot/
+cp README.md target/npm-build/mastodon_bot/
 tar -cz -C target/npm-build -f target/npm-build.tgz .
 
 npm publish ./target/npm-build.tgz --access public
@@ -32,10 +32,10 @@ shadow-cljs release app
 shadow-cljs release app
 chmod a+x mastodon-bot.js
 rm -rf target/npm-build 
-mkdir target/npm-build
-cp mastodon-bot.js target/npm-build/
-cp package.json target/npm-build/
-cp README.md target/npm-build/
+mkdir -p target/npm-build/mastodon_bot
+cp mastodon-bot.js target/npm-build/mastodon_bot/
+cp package.json target/npm-build/mastodon_bot/
+cp README.md target/npm-build/mastodon_bot/
 tar -cz -C target/npm-build -f target/npm-build.tgz .
 
 npm publish ./target/npm-build.tgz --access public


### PR DESCRIPTION
the npm package tgz should contain a single folder containing the package.json
and other resources. See https://docs.npmjs.com/cli/publish.

I suspect this is also the reason the README cannot be found
for https://www.npmjs.com/package/mastodon-bot/v/1.0.1