### PR TITLE
Publish the target directory without creating our own tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,5 +99,4 @@ jobs:
         cp target/mastodon-bot.js.sha512 target/npm-build/mastodon_bot/
         cp package.json target/npm-build/mastodon_bot/
         cp README.md target/npm-build/mastodon_bot/
-        tar -cz -C target/npm-build -f target/npm-build.tgz .
-        npm publish ./target/npm-build.tgz --access public --dry-run
+        npm publish ./target/npm-build --access public --dry-run

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,13 +7,12 @@ shadow-cljs compile test
 shadow-cljs release app
 chmod a+x mastodon-bot.js
 rm -rf target/npm-build 
-mkdir -p target/npm-build/mastodon_bot
-cp mastodon-bot.js target/npm-build/mastodon_bot/
-cp package.json target/npm-build/mastodon_bot/
-cp README.md target/npm-build/mastodon_bot/
-tar -cz -C target/npm-build -f target/npm-build.tgz .
+mkdir target/npm-build
+cp mastodon-bot.js target/npm-build
+cp package.json target/npm-build
+cp README.md target/npm-build
 
-npm publish ./target/npm-build.tgz --access public
+npm publish ./target/npm-build --access public
 ```
 
 ## prod release (should be done from master)
@@ -32,13 +31,12 @@ shadow-cljs release app
 shadow-cljs release app
 chmod a+x mastodon-bot.js
 rm -rf target/npm-build 
-mkdir -p target/npm-build/mastodon_bot
-cp mastodon-bot.js target/npm-build/mastodon_bot/
-cp package.json target/npm-build/mastodon_bot/
-cp README.md target/npm-build/mastodon_bot/
-tar -cz -C target/npm-build -f target/npm-build.tgz .
+mkdir target/npm-build
+cp mastodon-bot.js target/npm-build
+cp package.json target/npm-build
+cp README.md target/npm-build
 
-npm publish ./target/npm-build.tgz --access public
+npm publish ./target/npm-build --access public
 
 # Bump version
 vi shadow-cljs.edn

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mastodon-bot",
   "description": "Bot to publish twitter, tumblr or rss posts to an mastodon account.",
   "author": "Dmitri Sotnikov",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/yogthos/mastodon-bot",
   "repository": "https://github.com/yogthos/mastodon-bot",
   "license": "MIT",


### PR DESCRIPTION
This way 'npm publish' works and the package correctly has the
resources in a '/package' directory inside the tarball.

Tested by publishing locally, indeed the README is now correctly
shown at https://www.npmjs.com/package/mastodon-bot/v/1.0.1-test-raboof-3

Will release 1.0.2 from master after merging